### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             arch: x64
+          - os: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
 
     runs-on: ${{ matrix.os }}
 
@@ -49,21 +52,21 @@ jobs:
           fi
 
       - name: Checkout alma source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: yetone/alma
           token: ${{ secrets.ALMA_REPO_TOKEN }}
           ref: ${{ steps.params.outputs.ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
-          version: 9
+          version: 10
 
       - name: Get pnpm store directory
         shell: bash
@@ -71,7 +74,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-${{ matrix.arch }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -198,7 +201,7 @@ jobs:
 
       # Upload artifacts for the publish job
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: build-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
@@ -230,7 +233,7 @@ jobs:
           fi
 
       - name: Checkout alma source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: yetone/alma
           token: ${{ secrets.ALMA_REPO_TOKEN }}
@@ -240,13 +243,13 @@ jobs:
 
       # Download all build artifacts
       - name: Download macOS arm64 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: build-mac-arm64
           path: dist-electron-mac-arm64
 
       - name: Download macOS x64 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: build-mac-x64
           path: dist-electron-mac-x64
@@ -300,15 +303,15 @@ jobs:
           rm -rf dist-electron-mac-arm64 dist-electron-mac-x64
 
       - name: Download Windows x64 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: build-win-x64
           path: dist-electron
 
-      - name: Download Linux x64 artifacts
-        uses: actions/download-artifact@v4
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: build-linux-x64
+          pattern: build-linux-*  # arch = x64 and arm64
           path: dist-electron
 
       - name: List artifacts
@@ -383,7 +386,7 @@ jobs:
             -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: 2023-06-01" \
             -d "$(jq -n --arg prompt "$PROMPT" '{
-              "model": "claude-sonnet-4-20250514",
+              "model": "claude-sonnet-4-5-20250929",
               "max_tokens": 1024,
               "messages": [{"role": "user", "content": $prompt}]
             }')")
@@ -432,7 +435,7 @@ jobs:
           done
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: v${{ steps.params.outputs.version }}
           name: Alma v${{ steps.params.outputs.version }}


### PR DESCRIPTION
### Chores
- Update GitHub Actions and use SHA pinning for improved security
- Update Node.js 20 to 24 (latest LTS)
- Update pnpm to 9 to 10
- Update claude-sonnet-4-20250514 to claude-sonnet-4-5-20250929 (same [pricing](https://platform.claude.com/docs/en/about-claude/pricing))
- Add Ubuntu arm64 builds
- Let Dependabot update GitHub Actions